### PR TITLE
Bumped copyright end year to current year

### DIFF
--- a/README
+++ b/README
@@ -43,7 +43,7 @@ You can also look for information at:
 
 LICENSE AND COPYRIGHT
 
-Copyright (C) 2014 - 2016 Mohammad S Anwar
+Copyright (C) 2014 - 2019 Mohammad S Anwar
 
 This program is free software; you can redistribute it and/or modify it under the
 terms of the the Artistic License (2.0).You may obtain a copy of the full license

--- a/lib/Map/Tube/NYC.pm
+++ b/lib/Map/Tube/NYC.pm
@@ -160,7 +160,7 @@ L<http://search.cpan.org/dist/Map-Tube-NYC/>
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright (C) 2014 - 2016 Mohammad S Anwar.
+Copyright (C) 2014 - 2019 Mohammad S Anwar.
 
 This  program  is  free software; you can redistribute it and/or modify it under
 the  terms  of the the Artistic License (2.0). You may obtain a copy of the full

--- a/lib/Map/Tube/NYC/Line/BMTCanarsie.pm
+++ b/lib/Map/Tube/NYC/Line/BMTCanarsie.pm
@@ -117,7 +117,7 @@ L<http://search.cpan.org/dist/Map-Tube-NYC/>
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright (C) 2014 - 2016 Mohammad S Anwar.
+Copyright (C) 2014 - 2019 Mohammad S Anwar.
 
 This program  is  free software; you can redistribute it and / or modify it under
 the   terms  of the the Artistic License (2.0). You may obtain a copy of the full

--- a/lib/Map/Tube/NYC/Line/BMTNassauStreet.pm
+++ b/lib/Map/Tube/NYC/Line/BMTNassauStreet.pm
@@ -108,7 +108,7 @@ L<http://search.cpan.org/dist/Map-Tube-NYC/>
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright (C) 2014 - 2016 Mohammad S Anwar.
+Copyright (C) 2014 - 2019 Mohammad S Anwar.
 
 This program  is  free software; you can redistribute it and / or modify it under
 the   terms  of the the Artistic License (2.0). You may obtain a copy of the full

--- a/lib/Map/Tube/NYC/Line/INDCrosstown.pm
+++ b/lib/Map/Tube/NYC/Line/INDCrosstown.pm
@@ -106,7 +106,7 @@ L<http://search.cpan.org/dist/Map-Tube-NYC/>
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright (C) 2014 - 2016 Mohammad S Anwar.
+Copyright (C) 2014 - 2019 Mohammad S Anwar.
 
 This program  is  free software; you can redistribute it and / or modify it under
 the   terms  of the the Artistic License (2.0). You may obtain a copy of the full

--- a/lib/Map/Tube/NYC/Line/INDEighthAvenue.pm
+++ b/lib/Map/Tube/NYC/Line/INDEighthAvenue.pm
@@ -167,7 +167,7 @@ L<http://search.cpan.org/dist/Map-Tube-NYC/>
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright (C) 2014 - 2016 Mohammad S Anwar.
+Copyright (C) 2014 - 2019 Mohammad S Anwar.
 
 This program  is  free software; you can redistribute it and / or modify it under
 the  terms  of the the Artistic License (2.0). You may obtain a  copy of the full

--- a/lib/Map/Tube/NYC/Line/INDSixthAvenue.pm
+++ b/lib/Map/Tube/NYC/Line/INDSixthAvenue.pm
@@ -114,7 +114,7 @@ L<http://search.cpan.org/dist/Map-Tube-NYC/>
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright (C) 2014 - 2016 Mohammad S Anwar.
+Copyright (C) 2014 - 2019 Mohammad S Anwar.
 
 This program  is  free software; you can redistribute it and / or modify it under
 the  terms  of the the Artistic License (2.0). You may obtain a  copy of the full

--- a/lib/Map/Tube/NYC/Line/IRTFlushing.pm
+++ b/lib/Map/Tube/NYC/Line/IRTFlushing.pm
@@ -119,7 +119,7 @@ L<http://search.cpan.org/dist/Map-Tube-NYC/>
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright (C) 2014 - 2016 Mohammad S Anwar.
+Copyright (C) 2014 - 2019 Mohammad S Anwar.
 
 This program  is  free software; you can redistribute it and / or modify it under
 the   terms  of the the Artistic License (2.0). You may obtain a copy of the full

--- a/lib/Map/Tube/NYC/Line/IRTLexingtonAvenue.pm
+++ b/lib/Map/Tube/NYC/Line/IRTLexingtonAvenue.pm
@@ -162,7 +162,7 @@ L<http://search.cpan.org/dist/Map-Tube-NYC/>
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright (C) 2014 - 2016 Mohammad S Anwar.
+Copyright (C) 2014 - 2019 Mohammad S Anwar.
 
 This program  is  free software; you can redistribute it and / or modify it under
 the   terms  of the the Artistic License (2.0). You may obtain a copy of the full


### PR DESCRIPTION
Just spotted that the year in the copyright notice was not updated with the latest release. I corrected it the `readme`, not sure if this is auto-generated.